### PR TITLE
Workarounds for VATSIM and other changes

### DIFF
--- a/MainViewModel.cs
+++ b/MainViewModel.cs
@@ -33,6 +33,8 @@ namespace fs2ff
         private bool _autoConnectEnabled = Preferences.Default.auto_connect_enabled;
         private bool _dataAttitudeEnabled = Preferences.Default.att_enabled;
         private bool _gdl90Enabled = Preferences.Default.gdl90_enabled;
+        private bool _hideTrafficEnabled = Preferences.Default.hide_static_traffic_enabled;
+        
         private bool _dataPositionEnabled = Preferences.Default.pos_enabled;
         private bool _dataTrafficEnabled = Preferences.Default.tfk_enabled;
         private bool  _dataStratusEnabled = Preferences.Default.stratus_enabled;
@@ -103,7 +105,7 @@ namespace fs2ff
             AutoConnecting
         }
 
-        public static string WindowTitle => $"fs2ff - {App.InformationalVersion}";
+        public static string WindowTitle => $"fs2ff (GDL90) - {App.InformationalVersion}";
 
         public uint AttitudeFrequency
         {
@@ -189,13 +191,26 @@ namespace fs2ff
                 {
                     this._gdl90Enabled = value;
                     Preferences.Default.gdl90_enabled = value;
-                    this.DataGdl90Enabled = value;
                     Preferences.Default.Save();
                     ResetDataSenderConnection();
                 }
             }
         }
 
+        public bool DataHideTrafficEnabled
+        {
+            get => this._hideTrafficEnabled;
+            set
+            {
+                if (value != this._hideTrafficEnabled)
+                {
+                    this._hideTrafficEnabled = value;
+                    Preferences.Default.hide_static_traffic_enabled = value;
+                    Preferences.Default.Save();
+                }
+            }
+        }
+        
         public bool DataStratusEnabled
         {
             get => _dataStratusEnabled;

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -86,14 +86,15 @@
                 <CheckBox
                     IsChecked="{Binding AutoDetectIpEnabled, Mode=TwoWay}"
                     Content="Auto-detect*"
-                    ToolTip="Requires ForeFlight running in the foreground" />
+                    ToolTip="Attempts to locate the EFB already running" />
                 <TextBox
+                    ToolTip="Manually set the EFBs IP address here"
                     Text="{
                         Binding IpAddress, Mode=TwoWay,
                         Converter={c:IpAddressToStringConverter},
                         UpdateSourceTrigger=PropertyChanged, Delay=5000}"
                     Template="{StaticResource WatermarkTextBoxTemplate}"
-                    Tag="255.255.255.255"
+                    Tag="192.168.0.45"
                     Margin="0,10,0,0">
                     <i:Interaction.Behaviors>
                         <b:MoveFocusOnEnterBehavior />
@@ -105,17 +106,20 @@
                     Margin="0,20,0,5" />
                 <CheckBox
                     IsChecked="{Binding DataPositionEnabled, Mode=TwoWay}"
-                    Content="Position" />
+                    Content="Position"
+                    ToolTip="Enable/Disable sending of Position data to EFB"/>
                 <CheckBox
                     IsChecked="{Binding DataTrafficEnabled, Mode=TwoWay}"
-                    Content="Traffic" />
+                    Content="Traffic"
+                    ToolTip="Enable/Disable sending of Traffic data to EFB"/>
                 <CheckBox
                     IsChecked="{Binding DataHideTrafficEnabled, Mode=TwoWay}"
                     Content="Hide Static Traffic"
                     ToolTip="Filter out inactive aircraft statically placed on the ground at airports"/>
                 <CheckBox
                     IsChecked="{Binding DataAttitudeEnabled, Mode=TwoWay}"
-                    Content="Attitude" />
+                    Content="Attitude"
+                    ToolTip="Enable/Disable sending of Attitude data to EFB"/>
                 <CheckBox
                     IsChecked="{Binding DataGdl90Enabled, Mode=TwoWay}"
                     Content="Use GDL90 Protocol"
@@ -139,7 +143,8 @@
                     Maximum="{Binding AttitudeFrequencyMax, Converter={c:UIntToDoubleConverter}}"
                     Focusable="False"
                     TickPlacement="Both"
-                    IsSnapToTickEnabled="True" />
+                    IsSnapToTickEnabled="True"
+                    ToolTip="Adjusts the update rate of sending AHARS data to the EFB"/>
             </StackPanel>
         </ui:SplitView.Pane>
         <Grid>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -12,7 +12,7 @@
         Title="{Binding WindowTitle}"
         Icon="img\icon.ico"
         Width="600" Height="505"
-        MinWidth="600" MinHeight="505"
+        MinWidth="600" MinHeight="540"
         Closing="Window_Closing"
         Loaded="Window_Loaded"
         DataContext="{Binding Main, Source={StaticResource Locator}}">
@@ -109,6 +109,10 @@
                 <CheckBox
                     IsChecked="{Binding DataTrafficEnabled, Mode=TwoWay}"
                     Content="Traffic" />
+                <CheckBox
+                    IsChecked="{Binding DataHideTrafficEnabled, Mode=TwoWay}"
+                    Content="Hide Static Traffic"
+                    ToolTip="Filter out inactive aircraft statically placed on the ground at airports"/>
                 <CheckBox
                     IsChecked="{Binding DataAttitudeEnabled, Mode=TwoWay}"
                     Content="Attitude" />

--- a/Models/Gdl90Traffic.cs
+++ b/Models/Gdl90Traffic.cs
@@ -95,7 +95,17 @@ namespace fs2ff.Models
             trk /= Gdl90Util.TRACK_RESOLUTION;
             Msg[17] = Convert.ToByte(trk);
 
-            if (traffic.Category == "Helicopter")
+            if (traffic.MaxMach > 5)
+            {
+                // Space or trans-atmospheric vehicle (Dark Star)
+                Msg[18] = 15;
+            }
+            else if (traffic.MaxMach > 1.1 || traffic.MaxGforceSeen > 5)
+            {
+                // Highly Maneuverable > 5G acceleration and high speed (F18 and other High G aircraft)
+                Msg[18] = 6;
+            }
+            else if (traffic.Category == "Helicopter")
             {
                 Msg[18] = 0x7;
             }
@@ -104,24 +114,26 @@ namespace fs2ff.Models
                 if (traffic.MaxGrossWeight < 15500)
                 {
                     // Light
-                    Msg[18] = 0x1;
+                    Msg[18] = 1;
                 }
                 else if (traffic.MaxGrossWeight < 75000)
                 {
                     // Small
-                    Msg[18] = 0x2;
+                    Msg[18] = 2;
                 }
                 else if (traffic.MaxGrossWeight < 300000)
                 {
                     // Large
-                    Msg[18] = 0x2;
+                    Msg[18] = 3;
                 }
                 else
                 {
                     // Heavy (B747)
-                    Msg[18] = 0x5;
+                    Msg[18] = 5;
                 }
-                // TODO: Add more aircraft types (glider, high-speed, High Vortex, etc.)
+
+                // TODO: Add more aircraft types (glider, High Vortex, etc.)
+                // Could use the AtcModel to do a string lookup for a given set of aircraft etc.
             }
             else
             {

--- a/Models/Gdl90Traffic.cs
+++ b/Models/Gdl90Traffic.cs
@@ -64,7 +64,8 @@ namespace fs2ff.Models
             Msg[12] |= 0x01;
 
             // MSFS has a desire to show stationary planes on not on ground
-            if (!traffic.OnGround && (traffic.GroundVelocity > 0 || traffic.VerticalSpeed > 0))
+            // VATSIM likes to have some jitter and not put the plane on the ground
+            if (!traffic.OnGround && traffic.AltAboveGroundCG > 10 && (traffic.GroundVelocity != 0 || traffic.VerticalSpeed != 0))
             {
                 Msg[12] = (byte)(Msg[12] | 1 << 3);
 

--- a/Models/Traffic.cs
+++ b/Models/Traffic.cs
@@ -40,7 +40,8 @@ namespace fs2ff.Models
 
         public double MaxMach;
         public double MaxGforceSeen;
-
+        public bool LightBeaconOn;
+        public double AltAboveGroundCG;
     }
 
     public static class TrafficExtensions

--- a/Models/Traffic.cs
+++ b/Models/Traffic.cs
@@ -34,6 +34,13 @@ namespace fs2ff.Models
         public double AirspeedTrue;
         public uint TransponderCode;
         public TranssponderState TransponderState;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string AtcModel;
+
+        public double MaxMach;
+        public double MaxGforceSeen;
+
     }
 
     public static class TrafficExtensions

--- a/Preferences.Designer.cs
+++ b/Preferences.Designer.cs
@@ -12,7 +12,7 @@ namespace fs2ff {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Preferences : global::System.Configuration.ApplicationSettingsBase {
         
         private static Preferences defaultInstance = ((Preferences)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Preferences())));
@@ -46,52 +46,43 @@ namespace fs2ff {
                 this["att_enabled"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool gdl90_enabled
-        {
-            get
-            {
+        public bool gdl90_enabled {
+            get {
                 return ((bool)(this["gdl90_enabled"]));
             }
-            set
-            {
+            set {
                 this["gdl90_enabled"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool stratus_enabled
-        {
-            get
-            {
+        public bool stratus_enabled {
+            get {
                 return ((bool)(this["stratus_enabled"]));
             }
-            set
-            {
+            set {
                 this["stratus_enabled"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool stratux_enabled
-        {
-            get
-            {
+        public bool stratux_enabled {
+            get {
                 return ((bool)(this["stratux_enabled"]));
             }
-            set
-            {
+            set {
                 this["stratux_enabled"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -127,7 +118,7 @@ namespace fs2ff {
                 this["ip_detection_enabled"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]

--- a/Preferences.Designer.cs
+++ b/Preferences.Designer.cs
@@ -133,7 +133,7 @@ namespace fs2ff {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("20")]
+        [global::System.Configuration.DefaultSettingValueAttribute("10")]
         public uint att_freq {
             get {
                 return ((uint)(this["att_freq"]));

--- a/Preferences.Designer.cs
+++ b/Preferences.Designer.cs
@@ -154,5 +154,17 @@ namespace fs2ff {
                 this["ip_hint_time"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool hide_static_traffic_enabled {
+            get {
+                return ((bool)(this["hide_static_traffic_enabled"]));
+            }
+            set {
+                this["hide_static_traffic_enabled"] = value;
+            }
+        }
     }
 }

--- a/Preferences.settings
+++ b/Preferences.settings
@@ -35,5 +35,8 @@
     <Setting Name="ip_hint_time" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">10</Value>
     </Setting>
+    <Setting Name="hide_static_traffic_enabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Preferences.settings
+++ b/Preferences.settings
@@ -30,7 +30,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="att_freq" Type="System.UInt32" Scope="User">
-      <Value Profile="(Default)">20</Value>
+      <Value Profile="(Default)">10</Value>
     </Setting>
     <Setting Name="ip_hint_time" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">10</Value>

--- a/Preferences.settings
+++ b/Preferences.settings
@@ -8,6 +8,15 @@
     <Setting Name="att_enabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="gdl90_enabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="stratus_enabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="stratux_enabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="pos_enabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -15,16 +24,16 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ip_detection_enabled" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="auto_connect_enabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="att_freq" Type="System.UInt32" Scope="User">
-      <Value Profile="(Default)">6</Value>
+      <Value Profile="(Default)">20</Value>
     </Setting>
     <Setting Name="ip_hint_time" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">10</Value>
-    </Setting>
-    <Setting Name="auto_connect_enabled" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/SimConnect/SimConnectAdapter.cs
+++ b/SimConnect/SimConnectAdapter.cs
@@ -104,7 +104,7 @@ namespace fs2ff.SimConnect
             AddToDataDefinition(DEFINITION.Attitude, "AIRSPEED TRUE", "Knots");
             AddToDataDefinition(DEFINITION.Attitude, "PRESSURE ALTITUDE", "Feet");
             AddToDataDefinition(DEFINITION.Attitude, "VELOCITY WORLD Y", "Feet per minute");
-            AddToDataDefinition(DEFINITION.Attitude, "G FORCE", null);
+            AddToDataDefinition(DEFINITION.Attitude, "G FORCE", "Gforce");
 
             _simConnect?.RegisterDataDefineStruct<Attitude>(DEFINITION.Attitude);
         }
@@ -140,6 +140,10 @@ namespace fs2ff.SimConnect
             AddToDataDefinition(DEFINITION.Traffic, "AIRSPEED TRUE", "Knots");
             AddToDataDefinition(DEFINITION.Traffic, "TRANSPONDER CODE:1", null, SIMCONNECT_DATATYPE.INT32);
             AddToDataDefinition(DEFINITION.Traffic, "TRANSPONDER STATE:1", null, SIMCONNECT_DATATYPE.INT32);
+            AddToDataDefinition(DEFINITION.Traffic, "ATC MODEL", null, SIMCONNECT_DATATYPE.STRING32);
+            AddToDataDefinition(DEFINITION.Traffic, "MACH MAX OPERATE", "Mach", SIMCONNECT_DATATYPE.FLOAT64);
+            AddToDataDefinition(DEFINITION.Traffic, "MAX G FORCE", "Gforce", SIMCONNECT_DATATYPE.FLOAT64);
+
 
             _simConnect?.RegisterDataDefineStruct<Traffic>(DEFINITION.Traffic);
         }
@@ -224,7 +228,7 @@ namespace fs2ff.SimConnect
                     0, 0, 0);
             }
 
-            _simConnect?.RequestDataOnSimObjectType(REQUEST.TrafficAircraft, DEFINITION.Traffic, 92600, SIMCONNECT_SIMOBJECT_TYPE.AIRCRAFT);
+            _simConnect?.RequestDataOnSimObjectType(REQUEST.TrafficAircraft, DEFINITION.Traffic, 92600 * 2, SIMCONNECT_SIMOBJECT_TYPE.AIRCRAFT);
             _simConnect?.RequestDataOnSimObjectType(REQUEST.TrafficHelicopter, DEFINITION.Traffic, 92600, SIMCONNECT_SIMOBJECT_TYPE.HELICOPTER);
 
             _simConnect?.SubscribeToSystemEvent(EVENT.ObjectAdded, "ObjectAdded");
@@ -283,9 +287,16 @@ namespace fs2ff.SimConnect
             {
                 // Prevents all the parked aircraft from showing up on ADS-B
                 // Could also use Master power/Avionics state but a plane with a transponder will more likely have ADS-B
-                if (tfk.TransponderState != TranssponderState.Off)
+                //if (tfk.TransponderState != TranssponderState.Off)
+                if (tfk.OnGround == false || tfk.TransponderState != TranssponderState.Off)
                 {
                     await TrafficReceived.RaiseAsync(tfk, data.dwRequestID).ConfigureAwait(false);
+                }
+
+                // temp
+                if (tfk.TransponderState != TranssponderState.Off)
+                {
+                    Debug.WriteLine(tfk.TailNumber);
                 }
 
                 return;

--- a/SimConnect/SimConnectAdapter.cs
+++ b/SimConnect/SimConnectAdapter.cs
@@ -141,8 +141,8 @@ namespace fs2ff.SimConnect
             AddToDataDefinition(DEFINITION.Traffic, "TRANSPONDER CODE:1", null, SIMCONNECT_DATATYPE.INT32);
             AddToDataDefinition(DEFINITION.Traffic, "TRANSPONDER STATE:1", null, SIMCONNECT_DATATYPE.INT32);
             AddToDataDefinition(DEFINITION.Traffic, "ATC MODEL", null, SIMCONNECT_DATATYPE.STRING32);
-            AddToDataDefinition(DEFINITION.Traffic, "MACH MAX OPERATE", "Mach", SIMCONNECT_DATATYPE.FLOAT64);
-            AddToDataDefinition(DEFINITION.Traffic, "MAX G FORCE", "Gforce", SIMCONNECT_DATATYPE.FLOAT64);
+            AddToDataDefinition(DEFINITION.Traffic, "MACH MAX OPERATE", "Mach");
+            AddToDataDefinition(DEFINITION.Traffic, "MAX G FORCE", "Gforce");
             AddToDataDefinition(DEFINITION.Traffic, "LIGHT BEACON", "Bool", SIMCONNECT_DATATYPE.INT32);
             AddToDataDefinition(DEFINITION.Traffic, "PLANE ALT ABOVE GROUND MINUS CG", "Feet");
             
@@ -290,7 +290,7 @@ namespace fs2ff.SimConnect
             {
                 // Prevents all the parked aircraft from showing up on ADS-B
                 // Modified to work better with VATSIM since it doesn't report Transponder state
-                if (tfk.OnGround == false || tfk.TransponderState != TranssponderState.Off || tfk.LightBeaconOn)
+                if (!ViewModelLocator.Main.DataHideTrafficEnabled || !tfk.OnGround || tfk.TransponderState != TranssponderState.Off || tfk.LightBeaconOn)
                 {
                     await TrafficReceived.RaiseAsync(tfk, data.dwRequestID).ConfigureAwait(false);
                 }

--- a/SimConnect/SimConnectAdapter.cs
+++ b/SimConnect/SimConnectAdapter.cs
@@ -143,9 +143,12 @@ namespace fs2ff.SimConnect
             AddToDataDefinition(DEFINITION.Traffic, "ATC MODEL", null, SIMCONNECT_DATATYPE.STRING32);
             AddToDataDefinition(DEFINITION.Traffic, "MACH MAX OPERATE", "Mach", SIMCONNECT_DATATYPE.FLOAT64);
             AddToDataDefinition(DEFINITION.Traffic, "MAX G FORCE", "Gforce", SIMCONNECT_DATATYPE.FLOAT64);
+            AddToDataDefinition(DEFINITION.Traffic, "LIGHT BEACON", "Bool", SIMCONNECT_DATATYPE.INT32);
+            AddToDataDefinition(DEFINITION.Traffic, "PLANE ALT ABOVE GROUND MINUS CG", "Feet");
+            
 
 
-            _simConnect?.RegisterDataDefineStruct<Traffic>(DEFINITION.Traffic);
+             _simConnect?.RegisterDataDefineStruct<Traffic>(DEFINITION.Traffic);
         }
 
         private void RequestAttitudeData(object? _)
@@ -286,17 +289,10 @@ namespace fs2ff.SimConnect
                 data.dwData?.FirstOrDefault() is Traffic tfk)
             {
                 // Prevents all the parked aircraft from showing up on ADS-B
-                // Could also use Master power/Avionics state but a plane with a transponder will more likely have ADS-B
-                //if (tfk.TransponderState != TranssponderState.Off)
-                if (tfk.OnGround == false || tfk.TransponderState != TranssponderState.Off)
+                // Modified to work better with VATSIM since it doesn't report Transponder state
+                if (tfk.OnGround == false || tfk.TransponderState != TranssponderState.Off || tfk.LightBeaconOn)
                 {
                     await TrafficReceived.RaiseAsync(tfk, data.dwRequestID).ConfigureAwait(false);
-                }
-
-                // temp
-                if (tfk.TransponderState != TranssponderState.Off)
-                {
-                    Debug.WriteLine(tfk.TailNumber);
                 }
 
                 return;

--- a/UpdateChecker.cs
+++ b/UpdateChecker.cs
@@ -13,7 +13,7 @@ namespace fs2ff
                 using var handler = new HttpClientHandler { AllowAutoRedirect = false };
                 using var client = new HttpClient(handler);
 
-                var response = await client.GetAsync(new Uri("https://github.com/astenlund/fs2ff/releases/latest")).ConfigureAwait(false);
+                var response = await client.GetAsync(new Uri("https://github.com/jeffdamp-wave/fs2ff/releases/latest")).ConfigureAwait(false);
                 var location = response.Headers.Location;
                 var versionStr = location?.Segments[^1];
 

--- a/fs2ff.csproj
+++ b/fs2ff.csproj
@@ -21,12 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.FlightSimulator.SimConnect, Version=11.0.62651.3, Culture=neutral, PublicKeyToken=baf445ffb3a06b5c">
-      <HintPath>lib\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ContentWithTargetPath Include="lib\concrt140.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>concrt140.dll</TargetPath>
@@ -65,6 +59,9 @@
 
   <ItemGroup>
     <None Remove="img\icon.ico" />
+    <Reference Include="Microsoft.FlightSimulator.SimConnect">
+      <HintPath>lib\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
+    </Reference>
     <Resource Include="img\icon.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Resource>

--- a/fs2ff.csproj
+++ b/fs2ff.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.1.15</Version>
+    <Version>1.1.16</Version>
     <StartupObject />
   </PropertyGroup>
 


### PR DESCRIPTION
1. VATSIM MP aircraft don't report a transponder state or code.  Used Tail beacon light or > 10 feet off the ground as an indicator of non-static traffic at airports.
2. Added an option to filter this traffic.
3. Pointing this version to my release instead of astenlunds.
4. Updated the window title.
5. Fixed a bug where large aircraft reported as small.
6. Added highly maneuverable and trans-atmospheric aircraft types