### PR TITLE
Enhance Ownship Message Filtering in fs2ff to Support MSFS 2024

### DIFF
--- a/.github/workflows/dotnet-desktop-pull.yml
+++ b/.github/workflows/dotnet-desktop-pull.yml
@@ -1,14 +1,11 @@
-
 name: .NET Core Desktop Build
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
-
   build:
-
     strategy:
       matrix:
         configuration: [Debug, Release]
@@ -20,23 +17,29 @@ jobs:
       Platform_Name: win-x64
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
+      # Install the .NET Core workload
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.3.1
+      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.3.1
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Build the application
-      run: dotnet publish --self-contained -c  $env:Configuration -r  $env:Platform_Name $env:Solution_Name
-      env:
-        Configuration: ${{ matrix.configuration }}
+      # Restore the application to populate the obj folder with RuntimeIdentifiers
+      - name: Build the application
+        run: dotnet publish --self-contained -c  $env:Configuration -r  $env:Platform_Name $env:Solution_Name
+        env:
+          Configuration: ${{ matrix.configuration }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fs2ff
+          path: bin/Release/net8.0-windows/win-x64/publish

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,16 +1,12 @@
-
 name: .NET Core Desktop Release
 
 on:
   push:
-    branches: [ "master" ]
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-
   build:
-
     strategy:
       matrix:
         configuration: [Release]
@@ -26,42 +22,42 @@ jobs:
       Platform_Name: win-x64
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
+      # Install the .NET Core workload
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.3.1
+      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.3.1
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Build the application
-      run: dotnet publish --self-contained -c  $env:Configuration -r  $env:Platform_Name $env:Solution_Name
-      env:
-        Configuration: ${{ matrix.configuration }}
+      # Restore the application to populate the obj folder with RuntimeIdentifiers
+      - name: Build the application
+        run: dotnet publish --self-contained -c  $env:Configuration -r  $env:Platform_Name $env:Solution_Name
+        env:
+          Configuration: ${{ matrix.configuration }}
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: csexton/release-asset-action@v3
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        pattern: fs2ff/bin/Release/net8.0-windows/win-x64/publish/*.*
-        release-url: ${{ steps.create_release.outputs.upload_url }}
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: csexton/release-asset-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: bin/Release/net8.0-windows/win-x64/publish/*.*
+          release-url: ${{ steps.create_release.outputs.upload_url }}

--- a/fs2ff.csproj
+++ b/fs2ff.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.8.4</Version>
+    <Version>1.8.5</Version>
     <StartupObject />
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>


### PR DESCRIPTION
This pull request addresses an issue encountered in fs2ff when using Microsoft Flight Simulator 2024.

#### Problem:

 * While traffic data continued to function correctly, ownship information was lost within the application.
 * Investigation revealed that the ID of the local aircraft (ownship) is not consistently 0 or 1, particularly in multiplayer scenarios. The object ID can vary dynamically.

#### Solution:

This pull request modifies the traffic packet filtering logic in fs2ff.

 * Instead of relying on fixed ownship IDs (0 or 1), the filtering mechanism now excludes ownship information based on the object ID received for owner requests.
* This ensures accurate traffic data representation regardless of the assigned object ID for the local aircraft.

Thank you for your GDL90 port. Aside from this minor issue, it has been performing great.